### PR TITLE
feat(Makefile): dodanie Makefile dla wygody

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@
 
 1. Zainstaluj QuickCheck: `cabal install --lib QuickCheck`
 2. Umieść pliki `Graph.hs` oraz `Set.hs` z rozwiązaniem w katalogu `zad01/`
-3. Wczytaj plik z testami do `ghci` np. dla wszystkich testów wykonaj
-   `ghci TestAll.hs`
-4. Uruchom testy wpisując do interpretera ghci `main`
+3. Odpal `make`
+4. Wykonaj `TestAll`
 
 ### Dodawanie testów
 

--- a/zad01/.gitignore
+++ b/zad01/.gitignore
@@ -1,2 +1,7 @@
 Graph.hs
 Set.hs
+
+# Wyniki kompilacji
+TestAll
+*.hi
+*.o

--- a/zad01/Makefile
+++ b/zad01/Makefile
@@ -1,0 +1,5 @@
+all:
+	ghc -O -Wall -Werror -o TestAll TestAll.hs
+
+clean:
+	rm -f TestAll *.hi *.o


### PR DESCRIPTION
Ręczne odpalanie testów jest okropne, więc napisałem bardzo prosty
Makefile, który pozwala na skompilowanie testów i uruchomienie jednego
pliku wykonywalnego.
