### PR TITLE
fix: dodanie brakujących sygnatur

### DIFF
--- a/zad01/TestAll.hs
+++ b/zad01/TestAll.hs
@@ -4,6 +4,7 @@ import qualified TestRelation
 import qualified TestFibonacci
 import qualified TestKwasow
 
+main :: IO ()
 main = do
   writeln ">>> [Official] Set"
   TestSet.main

--- a/zad01/TestBasicGraph.hs
+++ b/zad01/TestBasicGraph.hs
@@ -42,6 +42,7 @@ monadAssocProp' :: Basic Int -> Basic Int -> Basic Int -> Bool
 monadAssocProp' x y z = ((x >> y) >> z) == (x >> (y >> z))
 
 
+main :: IO ()
 main = do
        let monadTests = True
        writeln "connect left unit"

--- a/zad01/TestFibonacci.hs
+++ b/zad01/TestFibonacci.hs
@@ -3,6 +3,7 @@ import Graph
 import Test.QuickCheck
 import Set
 
+fibHelper :: (Ord t1, Num t1) => (t2 -> t2 -> t2) -> t2 -> t2 -> t1 -> t2
 fibHelper f a b n
     | n > 0 = fibHelper f b (f a b) (n-1)
     | otherwise = a  

--- a/zad01/TestKwasow.hs
+++ b/zad01/TestKwasow.hs
@@ -3,6 +3,7 @@ import Graph
 import Test.QuickCheck
 import Set
 
+suite1 :: IO ()
 suite1 = do
   quickCheck prop1
   quickCheck prop2
@@ -21,11 +22,13 @@ suite1 = do
     prop7 = todot (vertex @Basic 1) == "digraph {\n1;\n}"
     prop8 = todot (connect @Basic 1 2) == "digraph {\n1 -> 2;\n}"
 
+suite2 :: IO ()
 suite2 = do
   quickCheck prop1 where
     l = [1..100000] ++ [1..100000] ++ [1..100000] ++ [1..100000] ++ [1..100000]
     prop1 = toAscList (fromList l) == [1..100000]
 
+suite3 :: IO ()
 suite3 = do
   quickCheck prop1
   quickCheck prop2
@@ -40,6 +43,7 @@ suite3 = do
     prop5 = mergeV 21 37 34 example34 == example34
     prop6 = mergeV 1 2 12 (1*2) == (12*12)
 
+suite4 :: IO ()
 suite4 = do
   quickCheck prop1
   quickCheck prop2 where
@@ -47,6 +51,7 @@ suite4 = do
     prop2 = splitV 21 2 1 example34 == example34
 
 -- Main
+main :: IO ()
 main = do
       -- Begin
       writeln "Starting Kwasow tests"

--- a/zad01/TestRelation.hs
+++ b/zad01/TestRelation.hs
@@ -24,6 +24,7 @@ distributive x y z = x*(y+z) == x*y + x*z
 decomposable :: Relation Int -> Relation Int -> Relation Int -> Bool
 decomposable x y z = x*y*z == x*y + x*z + y*z
 
+main :: IO ()
 main = do
        writeln "connect left unit"       
        quickCheck leftUnit

--- a/zad01/TestSet.hs
+++ b/zad01/TestSet.hs
@@ -22,6 +22,7 @@ reasonable :: Int -> Set Int -> Bool
 reasonable a s = member a (singleton a <> s)
 
 
+main :: IO ()
 main = do
        writeln "testing left unit"       
        quickCheck leftUnit


### PR DESCRIPTION
Niektóre funkcje nie miały podanych sygnatur, co powodowało dodatkowe
ostrzeżenia kompilatora. Dodałem te sygnatury.
